### PR TITLE
Add .kiro/steering files for Whack-a-Mole project

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,52 @@
+# Whack-a-Mole - Product Overview
+
+Whack-a-Mole is a browser-based arcade game with a persistent universal leaderboard. Players enter their name, then try to click moles as they pop up from a 3x3 grid within a 60-second time limit.
+
+## Game Mechanics
+
+| Concept | Detail |
+|---------|--------|
+| Grid | 3x3 grid of squares (holes) |
+| Mole spawn rate | Every 700ms a mole appears in a random square |
+| Game duration | 60 seconds countdown |
+| Scoring | +1 point per successful hit |
+| Max plausible score | 90 (enforced server-side) |
+| Player name | Required before playing, max 15 characters |
+| Input | Mouse click (`mousedown`) and touch (`touchstart`) supported |
+
+## Key User Flows
+
+### 1. Player Setup
+- User enters their name (max 15 characters) and clicks Submit
+- Name input is hidden and the game board is revealed
+
+### 2. Gameplay
+- User clicks "Start Game" to begin the 60-second countdown
+- Moles pop up in random squares every 700ms with a CSS transition animation
+- Clicking a mole increments the score; the mole disappears
+- Start button is disabled during gameplay
+
+### 3. Game Over
+- When the timer reaches zero, an alert displays the final score
+- The score is automatically saved to the leaderboard via POST to the API
+- The leaderboard refreshes to show updated rankings
+
+### 4. Leaderboard
+- Displays the top 5 scores across all players and sessions
+- Loaded on page load and refreshed after each game
+- Scores are sorted server-side by score descending
+- Shown as an ordered list below the game grid
+
+## Hosting
+
+- Frontend hosted on GitHub Pages: `https://ashoksriram92.github.io/whack-a-mole-gemini-cli-test/`
+- Backend API on AWS API Gateway: `https://sg5om8nni4.execute-api.us-east-1.amazonaws.com/Prod/leaderboard`
+- CORS is configured to allow requests only from the GitHub Pages origin
+
+## Visual Design
+
+- Earthy, outdoor color palette
+- Background: light green (`#c0d9af`)
+- Grid and leaderboard: brown tones (`#a08464`, `#7a6344`, `#534431`)
+- Mole: tan circle (`#be9767`) with brown border, animates up/down via CSS transition
+- Responsive layout with media query for screens under 600px

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,77 @@
+# Project Structure
+
+## Root Layout
+
+```
+whack-a-mole-gemini-cli-test/
+├── index.html             # Game UI (player setup, grid, leaderboard)
+├── script.js              # All frontend game logic and API calls
+├── style.css              # All styles (earthy theme, responsive)
+├── README.md              # Project overview and setup instructions
+├── .gitignore             # Ignores node_modules, .aws-sam, leaderboard.json
+└── aws/                   # Serverless backend (AWS SAM)
+    ├── template.yaml      # SAM template (API Gateway, Lambda, DynamoDB)
+    ├── samconfig.toml      # SAM CLI deployment config (us-east-1, stack: whack-a-mole)
+    └── src/handlers/       # Lambda function source code
+        ├── add-score.js        # POST /leaderboard handler
+        ├── get-scores.js       # GET /leaderboard handler
+        ├── add-score.test.js   # Jest tests for add-score
+        ├── get-scores.test.js  # Jest tests for get-scores
+        ├── package.json        # Node.js dependencies
+        ├── package-lock.json   # Locked dependency versions
+        └── Makefile            # SAM build targets (install, test, copy artifacts)
+```
+
+## Frontend (Root Directory)
+
+The frontend is three static files with no build step, no framework, and no bundler:
+
+- `index.html` - Single page with three sections: player name input, game container (hidden until name is submitted), and leaderboard container
+- `script.js` - Wrapped in a `DOMContentLoaded` listener. Handles mole spawning, click/touch events, countdown timer, score tracking, and REST API calls (`fetch`) to the leaderboard endpoint
+- `style.css` - Uses `StyleSheet`-style organization with a responsive media query for mobile
+
+### Frontend Data Flow
+
+```
+User clicks mole -> handleHit() -> score++ -> (on game over) saveScore()
+saveScore() -> fetch POST /leaderboard -> updateLeaderboard()
+updateLeaderboard() -> fetch GET /leaderboard -> render <li> elements
+```
+
+## Backend (aws/ Directory)
+
+The backend is an AWS SAM application with two Lambda functions sharing a single DynamoDB table.
+
+### Lambda Functions
+
+| Function | File | HTTP Method | Description |
+|----------|------|-------------|-------------|
+| AddScoreFunction | `add-score.js` | POST /leaderboard | Validates input, generates UUID, writes score to DynamoDB |
+| GetScoresFunction | `get-scores.js` | GET /leaderboard | Scans table, sorts by score descending, returns top 5 |
+
+### SAM Template Resources
+
+| Resource | Type | Purpose |
+|----------|------|---------|
+| LeaderboardTable | SimpleTable | DynamoDB table (`WhackAMoleLeaderboard`) with `id` (String) primary key |
+| GetScoresFunction | Serverless::Function | Lambda for retrieving scores (DynamoDBReadPolicy) |
+| AddScoreFunction | Serverless::Function | Lambda for saving scores (DynamoDBCrudPolicy) |
+| ServerlessRestApi | (implicit) | API Gateway with CORS configured for GitHub Pages origin |
+
+### Build Process (Makefile)
+
+Each Lambda function has a Makefile target that:
+1. Cleans `node_modules`
+2. Runs `npm install`
+3. Runs `npm test` (Jest)
+4. Copies the handler JS file to `$(ARTIFACTS_DIR)`
+
+This is triggered by `sam build` via the `BuildMethod: makefile` metadata in `template.yaml`.
+
+## Key Conventions
+
+- No build tools or bundler for the frontend -- edit files directly and refresh the browser
+- Backend dependencies live only in `aws/src/handlers/package.json`, not at the project root
+- CORS origin is hardcoded in both the SAM template (preflight) and each Lambda response (runtime)
+- The API URL is hardcoded in `script.js` as the `apiUrl` constant
+- DynamoDB table name defaults to `WhackAMoleLeaderboard` via environment variable fallback

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,69 @@
+# Tech Stack
+
+## Frontend
+
+- **Vanilla HTML5, CSS3, JavaScript (ES6+)** -- no frameworks, no transpilation, no bundler
+- Uses `fetch` API for HTTP requests (async/await)
+- CSS transitions for mole pop-up animation
+- Responsive design via CSS media queries
+- Touch events supported (`touchstart` with `preventDefault` to avoid ghost clicks)
+
+## Backend
+
+- **AWS SAM** (Serverless Application Model) for infrastructure-as-code
+- **AWS API Gateway** -- REST API with CORS support
+- **AWS Lambda** -- Node.js 18.x runtime, two functions:
+  - `add-score.js` -- validates input, generates UUID, writes to DynamoDB via `PutItemCommand`
+  - `get-scores.js` -- scans table, sorts, returns top 5 via `ScanCommand`
+- **Amazon DynamoDB** -- single table (`WhackAMoleLeaderboard`), provisioned at 1 RCU / 1 WCU
+- **Dependencies** (in `aws/src/handlers/package.json`):
+  - `uuid` ^9.0.0 -- generating unique score IDs
+  - `@aws-sdk/client-dynamodb` ^3.509.0 -- DynamoDB client (dev dependency, provided by Lambda runtime)
+  - `@aws-sdk/util-dynamodb` ^3.509.0 -- marshall/unmarshall helpers (dev dependency)
+
+## Testing
+
+- **Jest** ^29.0.0 -- unit tests for Lambda handlers
+- **aws-sdk-client-mock** ^3.0.0 -- mocks for DynamoDB client in tests
+- Tests are co-located with handlers: `add-score.test.js`, `get-scores.test.js`
+- Tests run as part of the SAM build process (Makefile targets)
+
+## Deployment
+
+### Frontend
+- Hosted on **GitHub Pages** at `https://ashoksriram92.github.io/whack-a-mole-gemini-cli-test/`
+- No build step required -- push static files to the repo
+
+### Backend
+- Deployed via **AWS SAM CLI** to `us-east-1`
+- Stack name: `whack-a-mole`
+- S3 bucket auto-resolved for deployment artifacts
+
+## Common Commands
+
+```bash
+# Frontend -- local development
+python3 -m http.server              # Serve frontend at http://localhost:8000
+
+# Backend -- tests
+cd aws/src/handlers
+npm install                         # Install dependencies
+npm test                            # Run Jest unit tests
+
+# Backend -- build and deploy (requires AWS CLI + SAM CLI)
+cd aws
+sam build                           # Build Lambda functions (runs npm install + tests via Makefile)
+sam deploy --guided                 # Deploy to AWS (first time, interactive)
+sam deploy                          # Deploy to AWS (subsequent, uses samconfig.toml)
+```
+
+## Environment Configuration
+
+| Setting | Value |
+|---------|-------|
+| AWS Region | us-east-1 |
+| DynamoDB Table | WhackAMoleLeaderboard |
+| API Gateway Stage | Prod |
+| CORS Allowed Origin | `https://ashoksriram92.github.io/whack-a-mole-gemini-cli-test/` |
+| Lambda Timeout | 3 seconds |
+| API URL (in script.js) | `https://sg5om8nni4.execute-api.us-east-1.amazonaws.com/Prod/leaderboard` |


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Replaces the previous steering files (which were for an unrelated Growve/React Native project) with new ones tailored to this Whack-a-Mole repository.

### Files created

- **`.kiro/steering/product.md`** - Product overview covering game mechanics (3x3 grid, 60s timer, scoring), user flows (player setup, gameplay, game over, leaderboard), hosting details, and visual design
- **`.kiro/steering/structure.md`** - Project structure documenting the frontend (three static files, no build step), backend (AWS SAM with Lambda + DynamoDB), data flow, and key conventions
- **`.kiro/steering/tech.md`** - Tech stack covering vanilla JS frontend, AWS SAM backend (Node.js 18.x Lambda, DynamoDB, API Gateway), testing (Jest + aws-sdk-client-mock), deployment (GitHub Pages + SAM CLI), and common commands

All content is derived from the actual source code in the repository.