### PR TITLE
feat: add pre-game countdown animation (closes #9)

### DIFF
--- a/e2e/tests/countdown.spec.js
+++ b/e2e/tests/countdown.spec.js
@@ -1,0 +1,61 @@
+const { test, expect } = require('@playwright/test');
+const { mockLeaderboardAPI } = require('./helpers');
+
+test.describe('Pre-game Countdown', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLeaderboardAPI(page);
+    page.on('dialog', async (dialog) => await dialog.accept());
+    await page.goto('/');
+    await page.fill('#player-name', 'TestPlayer');
+    await page.click('#submit-name');
+  });
+
+  test('countdown overlay becomes visible after clicking Start', async ({ page }) => {
+    await page.click('#start-button');
+    await expect(page.locator('#countdown-overlay')).toHaveClass(/active/);
+  });
+
+  test('countdown shows "3" as first text', async ({ page }) => {
+    await page.click('#start-button');
+    await expect(page.locator('#countdown-text')).toHaveText('3');
+  });
+
+  test('countdown shows "Go!" as final step', async ({ page }) => {
+    await page.click('#start-button');
+    // Wait for 3, 2, 1 to pass (~3 seconds)
+    await expect(page.locator('#countdown-text')).toHaveText('Go!', { timeout: 5000 });
+  });
+
+  test('countdown overlay is hidden after countdown completes', async ({ page }) => {
+    await page.click('#start-button');
+    // Wait for the full countdown (~4 seconds) plus buffer
+    await page.waitForTimeout(4500);
+    await expect(page.locator('#countdown-overlay')).not.toHaveClass(/active/);
+  });
+
+  test('moles do NOT appear during the countdown phase', async ({ page }) => {
+    await page.click('#start-button');
+    // During countdown (~4s), no moles should be visible
+    await page.waitForTimeout(2000);
+    await expect(page.locator('#countdown-overlay')).toHaveClass(/active/);
+    const moleCount = await page.locator('.mole.up').count();
+    expect(moleCount).toBe(0);
+  });
+
+  test('timer stays at 60 during countdown', async ({ page }) => {
+    await page.click('#start-button');
+    // Check at various points during countdown
+    await page.waitForTimeout(1500);
+    await expect(page.locator('#time-left')).toHaveText('60');
+    await page.waitForTimeout(1500);
+    await expect(page.locator('#time-left')).toHaveText('60');
+  });
+
+  test('start button remains disabled during countdown', async ({ page }) => {
+    await page.click('#start-button');
+    await page.waitForTimeout(1000);
+    await expect(page.locator('#start-button')).toBeDisabled();
+    await page.waitForTimeout(1000);
+    await expect(page.locator('#start-button')).toBeDisabled();
+  });
+});

--- a/e2e/tests/gameplay.spec.js
+++ b/e2e/tests/gameplay.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const { mockLeaderboardAPI } = require('./helpers');
 
+const COUNTDOWN_DURATION = 4500; // ~4s countdown + buffer
+
 test.describe('Gameplay', () => {
   test.beforeEach(async ({ page }) => {
     await mockLeaderboardAPI(page);
@@ -19,21 +21,23 @@ test.describe('Gameplay', () => {
 
   test('score starts at 0 and timer at 60', async ({ page }) => {
     await page.click('#start-button');
+    // Wait for countdown to finish
+    await page.waitForTimeout(COUNTDOWN_DURATION);
     await expect(page.locator('#score')).toHaveText('0');
     await expect(page.locator('#time-left')).toHaveText('60');
   });
 
   test('moles appear after starting game', async ({ page }) => {
     await page.click('#start-button');
-    // Moles appear every 700ms, wait for one
-    await expect(page.locator('.mole.up')).toBeVisible({ timeout: 3000 });
+    // Wait for countdown + mole spawn (700ms cycle)
+    await expect(page.locator('.mole.up')).toBeVisible({ timeout: COUNTDOWN_DURATION + 3000 });
   });
 
   test('clicking a mole increments the score', async ({ page }) => {
     await page.click('#start-button');
-    // Wait for a mole to appear
+    // Wait for a mole to appear (after countdown)
     const mole = page.locator('.mole.up');
-    await mole.waitFor({ state: 'visible', timeout: 3000 });
+    await mole.waitFor({ state: 'visible', timeout: COUNTDOWN_DURATION + 3000 });
     // Get parent square and click it (mousedown handler is on .square)
     const parentSquare = page.locator('.square:has(.mole.up)');
     await parentSquare.click();
@@ -44,7 +48,8 @@ test.describe('Gameplay', () => {
 
   test('timer counts down', async ({ page }) => {
     await page.click('#start-button');
-    await page.waitForTimeout(2500);
+    // Wait for countdown to finish + some gameplay time
+    await page.waitForTimeout(COUNTDOWN_DURATION + 2500);
     const timeText = await page.locator('#time-left').textContent();
     const timeVal = parseInt(timeText);
     expect(timeVal).toBeLessThan(60);
@@ -53,12 +58,18 @@ test.describe('Gameplay', () => {
 
   test('start button stays disabled during gameplay', async ({ page }) => {
     await page.click('#start-button');
+    // Check during countdown
     await page.waitForTimeout(1000);
+    await expect(page.locator('#start-button')).toBeDisabled();
+    // Check after countdown during gameplay
+    await page.waitForTimeout(COUNTDOWN_DURATION);
     await expect(page.locator('#start-button')).toBeDisabled();
   });
 
   test('multiple mole hits increment score correctly', async ({ page }) => {
     await page.click('#start-button');
+    // Wait for countdown to finish
+    await page.waitForTimeout(COUNTDOWN_DURATION);
     let hits = 0;
     // Try to hit 3 moles
     for (let i = 0; i < 3; i++) {

--- a/e2e/tests/hit-feedback.spec.js
+++ b/e2e/tests/hit-feedback.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const { mockLeaderboardAPI } = require('./helpers');
 
+const COUNTDOWN_DURATION = 4500; // ~4s countdown + buffer
+
 test.describe('Hit Feedback Animations', () => {
   test.beforeEach(async ({ page }) => {
     await mockLeaderboardAPI(page);
@@ -10,7 +12,7 @@ test.describe('Hit Feedback Animations', () => {
     await page.click('#submit-name');
     await page.click('#start-button');
     // Wait for a mole to appear
-    await page.locator('.mole.up').waitFor({ state: 'visible', timeout: 3000 });
+    await page.locator('.mole.up').waitFor({ state: 'visible', timeout: COUNTDOWN_DURATION + 3000 });
   });
 
   test('clicking a mole adds .hit class to the square', async ({ page }) => {

--- a/e2e/tests/keyboard-input.spec.js
+++ b/e2e/tests/keyboard-input.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const { mockLeaderboardAPI } = require('./helpers');
 
+const COUNTDOWN_DURATION = 4500; // ~4s countdown + buffer
+
 test.describe('Keyboard Input', () => {
   test.beforeEach(async ({ page }) => {
     await mockLeaderboardAPI(page);
@@ -15,7 +17,7 @@ test.describe('Keyboard Input', () => {
 
     // Wait for a mole to appear
     const mole = page.locator('.mole.up');
-    await mole.waitFor({ state: 'visible', timeout: 3000 });
+    await mole.waitFor({ state: 'visible', timeout: COUNTDOWN_DURATION + 3000 });
 
     // Find which square the mole is in
     const squareId = await page.locator('.square:has(.mole.up)').getAttribute('id');

--- a/e2e/tests/mole-sprite.spec.js
+++ b/e2e/tests/mole-sprite.spec.js
@@ -1,6 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const { mockLeaderboardAPI } = require('./helpers');
 
+const COUNTDOWN_DURATION = 4500; // ~4s countdown + buffer
+
 test.describe('Mole Sprite', () => {
   test.beforeEach(async ({ page }) => {
     await mockLeaderboardAPI(page);
@@ -10,7 +12,7 @@ test.describe('Mole Sprite', () => {
     await page.click('#submit-name');
     await page.click('#start-button');
     // Wait for a mole to appear
-    await page.locator('.mole.up').waitFor({ state: 'visible', timeout: 3000 });
+    await page.locator('.mole.up').waitFor({ state: 'visible', timeout: COUNTDOWN_DURATION + 3000 });
   });
 
   test('mole element has a background-image CSS property set', async ({ page }) => {
@@ -29,7 +31,7 @@ test.describe('Mole Sprite', () => {
     await expect(page.locator('body')).toHaveClass(/high-contrast/);
     // Wait for a mole to appear in high-contrast mode
     const mole = page.locator('.mole.up');
-    await mole.waitFor({ state: 'visible', timeout: 3000 });
+    await mole.waitFor({ state: 'visible', timeout: COUNTDOWN_DURATION + 3000 });
     await expect(mole).toBeVisible();
     const bgImage = await mole.evaluate((el) => getComputedStyle(el).backgroundImage);
     expect(bgImage).not.toBe('none');

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
             <div class="square" id="7"></div>
             <div class="square" id="8"></div>
             <div class="square" id="9"></div>
+            <div id="countdown-overlay"><span id="countdown-text"></span></div>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -10,6 +10,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const gameContainer = document.querySelector('.game-container');
     const leaderboardList = document.getElementById('leaderboard-list');
     const contrastToggle = document.getElementById('contrast-toggle');
+    const countdownOverlay = document.getElementById('countdown-overlay');
+    const countdownText = document.getElementById('countdown-text');
 
     if (localStorage.getItem('highContrast') === 'true') {
         document.body.classList.add('high-contrast');
@@ -166,16 +168,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function startGame() {
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+
+    async function runCountdown() {
+        countdownOverlay.classList.add('active');
+        const steps = ['3', '2', '1', 'Go!'];
+        for (const step of steps) {
+            countdownText.textContent = step;
+            countdownText.classList.add('countdown-animate');
+            await delay(1000);
+            countdownText.classList.remove('countdown-animate');
+        }
+        countdownOverlay.classList.remove('active');
+    }
+
+    async function startGame() {
         if (gameInProgress) return;
 
         score = 0;
         timeLeft = 60;
         scoreDisplay.textContent = score;
         timeLeftDisplay.textContent = timeLeft;
-        gameInProgress = true;
         startButton.disabled = true;
 
+        await runCountdown();
+
+        gameInProgress = true;
         timerId = setInterval(countDown, 1000);
         moveMole();
     }

--- a/style.css
+++ b/style.css
@@ -237,6 +237,52 @@ h1 {
     text-shadow: 1px 1px 3px #000000, 0 0 6px #FFD700;
 }
 
+/* Countdown overlay */
+#countdown-overlay {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+#countdown-overlay.active {
+    display: flex;
+}
+
+#countdown-text {
+    font-size: 5em;
+    font-weight: bold;
+    color: #FFFFFF;
+    text-shadow: 2px 2px 6px #534431, 0 0 10px #a08464;
+}
+
+@keyframes countdown-pop {
+    0% {
+        transform: scale(0.5);
+        opacity: 0;
+    }
+    40% {
+        transform: scale(1.2);
+        opacity: 1;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 0;
+    }
+}
+
+.countdown-animate {
+    animation: countdown-pop 900ms ease-out forwards;
+}
+
+.high-contrast #countdown-text {
+    color: #FFD700;
+    text-shadow: 2px 2px 6px #000000, 0 0 10px #FFD700;
+}
+
 /* Media query for smaller screens */
 @media screen and (max-width: 600px) {
     body {


### PR DESCRIPTION
This pull request was generated by @kiro-agent :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds a "3... 2... 1... Go!" countdown animation after clicking Start Game, giving players a moment to prepare before gameplay begins. This replaces the previous PR #24 which had merge conflicts.

### Changes
- **`index.html`**: Added `#countdown-overlay` with `#countdown-text` inside `.grid`
- **`style.css`**: Added countdown overlay styles (absolute positioning, semi-transparent backdrop, z-index 20), `@keyframes countdown-pop` scale/fade animation, and high-contrast variant with gold text
- **`script.js`**: Added reusable `delay()` helper, `async runCountdown()` function that displays 3-2-1-Go! with CSS pop animation, and made `startGame()` async to await countdown before starting timers/moles
- **`e2e/tests/countdown.spec.js`**: 7 new Playwright tests covering overlay visibility, text sequencing, post-countdown hide, mole prevention during countdown, timer freeze, and button state
- Updated existing e2e tests (`gameplay.spec.js`, `keyboard-input.spec.js`, `hit-feedback.spec.js`, `mole-sprite.spec.js`) with `COUNTDOWN_DURATION` constant to account for the ~4s countdown delay

### Testing
- All 55 e2e tests pass (7 new + 48 existing with timeout adjustments)
- Zero regressions

Supersedes PR #24 (which had merge conflicts after PRs #22 and #23 were merged first).

Closes #9